### PR TITLE
feat: add resource manager for ensuring device plugin and accelerator…

### DIFF
--- a/pkg/utils/status/status.go
+++ b/pkg/utils/status/status.go
@@ -1,0 +1,70 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+)
+
+// UpdateStatusConditionIfNotMatch updates the workspace status condition if it doesn't match the current values
+func UpdateStatusConditionIfNotMatch(ctx context.Context, c client.Client, wObj *kaitov1beta1.Workspace, cType kaitov1beta1.ConditionType,
+	cStatus metav1.ConditionStatus, cReason, cMessage string) error {
+	if curCondition := meta.FindStatusCondition(wObj.Status.Conditions, string(cType)); curCondition != nil {
+		if curCondition.Status == cStatus && curCondition.Reason == cReason && curCondition.Message == cMessage {
+			// Nothing to change
+			return nil
+		}
+	}
+	klog.InfoS("updateStatusCondition", "workspace", klog.KObj(wObj), "conditionType", cType, "status", cStatus, "reason", cReason, "message", cMessage)
+	cObj := metav1.Condition{
+		Type:               string(cType),
+		Status:             cStatus,
+		Reason:             cReason,
+		ObservedGeneration: wObj.GetGeneration(),
+		Message:            cMessage,
+		LastTransitionTime: metav1.Now(),
+	}
+	return UpdateWorkspaceStatus(ctx, c, &client.ObjectKey{Name: wObj.Name, Namespace: wObj.Namespace}, &cObj)
+}
+
+// UpdateWorkspaceStatus updates the workspace status with the provided condition
+func UpdateWorkspaceStatus(ctx context.Context, c client.Client, name *client.ObjectKey, condition *metav1.Condition) error {
+	return retry.OnError(retry.DefaultRetry,
+		func(err error) bool {
+			return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) || apierrors.IsConflict(err)
+		},
+		func() error {
+			// Read the latest version to avoid update conflict.
+			wObj := &kaitov1beta1.Workspace{}
+			if err := c.Get(ctx, *name, wObj); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			}
+			if condition != nil {
+				meta.SetStatusCondition(&wObj.Status.Conditions, *condition)
+			}
+			return c.Status().Update(ctx, wObj)
+		})
+}

--- a/pkg/workspace/resource/node_resource.go
+++ b/pkg/workspace/resource/node_resource.go
@@ -1,0 +1,330 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
+	"github.com/kaito-project/kaito/pkg/utils/resources"
+	"github.com/kaito-project/kaito/pkg/utils/status"
+)
+
+type NodeResourceManager struct {
+	client.Client
+}
+
+func NewNodeResourceManager(c client.Client) *NodeResourceManager {
+	return &NodeResourceManager{
+		Client: c,
+	}
+}
+
+func (c *NodeResourceManager) EnsureNodeResource(ctx context.Context, wObj *kaitov1beta1.Workspace) (bool, error) {
+	// ensure Nvidia device plugins are ready for the workspace when instance type is known.
+	knownGPUConfig, _ := utils.GetGPUConfigBySKU(wObj.Resource.InstanceType)
+	if knownGPUConfig != nil {
+		devicePluginsReady, err := c.ensureNvidiaDevicePluginsReady(ctx, wObj)
+		if !devicePluginsReady || err != nil {
+			return devicePluginsReady, err
+		}
+	}
+
+	// update the workspace status condition and nodes to indicate all resources are ready
+	if err := c.updateWorkspaceStatusIfNeeded(ctx, wObj); err != nil {
+		klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+		return false, err
+	}
+
+	klog.InfoS("All resources are ready for workspace", "workspace", klog.KObj(wObj))
+	return true, nil
+}
+
+// ensureNvidiaDevicePluginsReady ensures that NVIDIA device plugins are ready on all nodes for the workspace
+func (c *NodeResourceManager) ensureNvidiaDevicePluginsReady(ctx context.Context, wObj *kaitov1beta1.Workspace) (bool, error) {
+	requiredProvisionedNodeCount, err := nodeclaim.GetRequiredNodeClaimsCount(ctx, c.Client, wObj)
+	if err != nil {
+		return false, fmt.Errorf("failed to get required node claims count: %w", err)
+	}
+
+	// get all ready nodes for the workspace from nodeclaims
+	nodes, err := c.getReadyNodesFromNodeClaims(ctx, wObj)
+	if err != nil {
+		// Update status condition to indicate error getting nodes
+		if updateErr := status.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+			"NodeListError", fmt.Sprintf("Failed to get nodes for workspace: %v", err)); updateErr != nil {
+			klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+		}
+		return false, fmt.Errorf("failed to get nodes for workspace: %w", err)
+	}
+
+	// Check if the number of nodes matches the target count
+	if len(nodes) != requiredProvisionedNodeCount {
+		// Update status condition to indicate node count mismatch
+		if updateErr := status.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+			"NodeCountMismatch", fmt.Sprintf("Node count (%d) does not match target provisioned (%d)", len(nodes), requiredProvisionedNodeCount)); updateErr != nil {
+			klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+		}
+
+		klog.V(4).InfoS("Node count does not match target, waiting for nodes to be ready",
+			"workspace", klog.KObj(wObj),
+			"currentNodes", len(nodes),
+			"targetProvisionedNodeCount", requiredProvisionedNodeCount)
+		return false, nil
+	}
+
+	// Check each node for NVIDIA accelerator label and GPU capacity
+	for _, node := range nodes {
+		// Check if node has the required accelerator label
+		if accelerator, exists := node.Labels[resources.LabelKeyNvidia]; !exists || accelerator != resources.LabelValueNvidia {
+			klog.InfoS("Adding accelerator label to node",
+				"workspace", klog.KObj(wObj),
+				"node", node.Name,
+				"currentAccelerator", accelerator)
+
+			// Add the accelerator label to the node
+			if node.Labels == nil {
+				node.Labels = make(map[string]string)
+			}
+			node.Labels[resources.LabelKeyNvidia] = resources.LabelValueNvidia
+
+			if err := c.Client.Update(ctx, node); err != nil {
+				// Update status condition to indicate node update failure
+				if updateErr := status.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+					"NodeUpdateError", fmt.Sprintf("Failed to update node %s with accelerator label: %v", node.Name, err)); updateErr != nil {
+					klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+				}
+				return false, fmt.Errorf("failed to update node %s with accelerator label: %w", node.Name, err)
+			}
+
+			klog.InfoS("Successfully added accelerator label to node",
+				"workspace", klog.KObj(wObj),
+				"node", node.Name)
+		}
+
+		// Check if node has GPU capacity (nvidia.com/gpu resource should be > 0)
+		gpuCapacity := node.Status.Capacity[resources.CapacityNvidiaGPU]
+		if gpuCapacity.IsZero() {
+			// Update status condition to indicate GPU capacity is not ready
+			if updateErr := status.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+				"GPUCapacityNotReady", fmt.Sprintf("Node %s has zero GPU capacity", node.Name)); updateErr != nil {
+				klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+			}
+
+			klog.V(4).InfoS("Node has zero GPU capacity",
+				"workspace", klog.KObj(wObj),
+				"node", node.Name,
+				"gpuCapacity", gpuCapacity.String())
+			return false, nil
+		}
+	}
+
+	klog.InfoS("All nodes have NVIDIA device plugins ready",
+		"workspace", klog.KObj(wObj),
+		"nodeCount", len(nodes))
+	return true, nil
+}
+
+// getReadyNodesFromNodeClaims retrieves all ready nodes that are associated with NodeClaims for the workspace.
+// This function excludes preferred nodes and only returns nodes that were provisioned through NodeClaims.
+// It's primarily used for device plugin management where we need to ensure GPU nodes created by
+// NodeClaims have the proper NVIDIA device plugins installed.
+func (c *NodeResourceManager) getReadyNodesFromNodeClaims(ctx context.Context, wObj *kaitov1beta1.Workspace) ([]*corev1.Node, error) {
+	// First get the NodeClaims for this workspace
+	nodeClaims, err := nodeclaim.GetExistingNodeClaims(ctx, c.Client, wObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NodeClaims: %w", err)
+	}
+
+	nodes := make([]*corev1.Node, 0, len(nodeClaims))
+
+	// For each NodeClaim, get the corresponding Node
+	for _, nodeClaim := range nodeClaims {
+		if nodeClaim.Status.NodeName == "" {
+			// NodeClaim doesn't have a node assigned yet
+			continue
+		}
+
+		node := &corev1.Node{}
+		nodeKey := client.ObjectKey{Name: nodeClaim.Status.NodeName}
+		if err := c.Client.Get(ctx, nodeKey, node); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Node doesn't exist yet, skip
+				continue
+			}
+			return nil, fmt.Errorf("failed to get node %s: %w", nodeClaim.Status.NodeName, err)
+		}
+
+		// skip if node is not ready
+		if !nodeclaim.IsNodeReady(node) {
+			klog.V(4).InfoS("Node is not ready, skipping",
+				"node", node.Name,
+				"workspace", klog.KObj(wObj))
+			continue
+		}
+
+		// skip if node instance type does not match workspace
+		if node.Labels[corev1.LabelInstanceTypeStable] != wObj.Resource.InstanceType {
+			klog.V(4).InfoS("Node instance type does not match workspace, skipping",
+				"node", node.Name,
+				"workspace", klog.KObj(wObj))
+			continue
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes, nil
+}
+
+// getReadyNodesMatchingLabelSelector retrieves all ready nodes that match the workspace's label selector.
+// This function includes both NodeClaim-provisioned nodes and preferred nodes, providing a comprehensive
+// view of all nodes available for the workspace. It uses the workspace.Resource.LabelSelector to filter
+// nodes across the entire cluster and is used for workspace status updates to reflect all available nodes.
+func (c *NodeResourceManager) getReadyNodesMatchingLabelSelector(ctx context.Context, wObj *kaitov1beta1.Workspace) ([]*corev1.Node, error) {
+	// List all nodes in the cluster
+	nodeList := &corev1.NodeList{}
+	listOpts := []client.ListOption{}
+
+	// If there's a label selector, add it to the list options
+	if wObj.Resource.LabelSelector != nil {
+		selector, err := metav1.LabelSelectorAsSelector(wObj.Resource.LabelSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert label selector: %w", err)
+		}
+		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
+	}
+
+	if err := c.Client.List(ctx, nodeList, listOpts...); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	// Filter nodes that are ready
+	readyNodes := make([]*corev1.Node, 0, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+
+		// Check if the node is ready
+		if !nodeclaim.IsNodeReady(node) {
+			klog.V(4).InfoS("Node is not ready, skipping",
+				"node", node.Name,
+				"workspace", klog.KObj(wObj))
+			continue
+		}
+
+		readyNodes = append(readyNodes, node)
+	}
+
+	klog.V(4).InfoS("Found ready nodes matching workspace label selector",
+		"workspace", klog.KObj(wObj),
+		"readyNodeCount", len(readyNodes))
+
+	return readyNodes, nil
+}
+
+// updateWorkspaceStatusIfNeeded updates the workspace status when WorkerNodes change or ResourceStatus condition is not true
+func (c *NodeResourceManager) updateWorkspaceStatusIfNeeded(ctx context.Context, wObj *kaitov1beta1.Workspace) error {
+	// Get all ready nodes that match the workspace's label selector
+	nodes, err := c.getReadyNodesMatchingLabelSelector(ctx, wObj)
+	if err != nil {
+		klog.ErrorS(err, "failed to get ready nodes for workspace status update", "workspace", klog.KObj(wObj))
+		return fmt.Errorf("failed to get ready nodes for workspace: %w", err)
+	}
+
+	// Extract node names from ready nodes
+	readyNodeNames := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		readyNodeNames = append(readyNodeNames, node.Name)
+	}
+
+	// Check if WorkerNodes need to be updated
+	readyNodeSet := sets.New(readyNodeNames...)
+	currentWorkerNodeSet := sets.New(wObj.Status.WorkerNodes...)
+	needsWorkerNodeUpdate := !readyNodeSet.Equal(currentWorkerNodeSet)
+
+	// Check if ResourceStatus condition is not true
+	needsResourceStatusUpdate := true
+	if resourceCondition := meta.FindStatusCondition(wObj.Status.Conditions, string(kaitov1beta1.ConditionTypeResourceStatus)); resourceCondition != nil {
+		if resourceCondition.Status == metav1.ConditionTrue && resourceCondition.Reason == "ResourcesReady" {
+			needsResourceStatusUpdate = false
+		}
+	}
+
+	// If no updates are needed, return early
+	if !needsWorkerNodeUpdate && !needsResourceStatusUpdate {
+		return nil
+	}
+
+	// Perform both updates in a single request
+	klog.InfoS("Updating workspace status",
+		"workspace", klog.KObj(wObj),
+		"updateWorkerNodes", needsWorkerNodeUpdate,
+		"updateResourceStatus", needsResourceStatusUpdate,
+		"previousNodes", wObj.Status.WorkerNodes,
+		"newNodes", readyNodeNames)
+
+	return c.updateWorkspaceStatusWithBothUpdates(ctx, &client.ObjectKey{Name: wObj.Name, Namespace: wObj.Namespace},
+		readyNodeNames, needsWorkerNodeUpdate, needsResourceStatusUpdate)
+}
+
+// updateWorkspaceStatusWithBothUpdates updates both WorkerNodes and ResourceStatus condition in a single request
+func (c *NodeResourceManager) updateWorkspaceStatusWithBothUpdates(ctx context.Context, name *client.ObjectKey,
+	workerNodes []string, updateWorkerNodes bool, updateResourceStatus bool) error {
+	return retry.OnError(retry.DefaultRetry,
+		func(err error) bool {
+			return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) || apierrors.IsConflict(err)
+		},
+		func() error {
+			// Read the latest version to avoid update conflict.
+			wObj := &kaitov1beta1.Workspace{}
+			if err := c.Client.Get(ctx, *name, wObj); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			}
+
+			// Update WorkerNodes if needed
+			if updateWorkerNodes {
+				wObj.Status.WorkerNodes = workerNodes
+			}
+
+			// Update ResourceStatus condition if needed
+			if updateResourceStatus {
+				condition := metav1.Condition{
+					Type:               string(kaitov1beta1.ConditionTypeResourceStatus),
+					Status:             metav1.ConditionTrue,
+					Reason:             "ResourcesReady",
+					ObservedGeneration: wObj.GetGeneration(),
+					Message:            "All resources are ready and nodes are available",
+					LastTransitionTime: metav1.Now(),
+				}
+				meta.SetStatusCondition(&wObj.Status.Conditions, condition)
+			}
+
+			return c.Client.Status().Update(ctx, wObj)
+		})
+}

--- a/pkg/workspace/resource/node_resource_test.go
+++ b/pkg/workspace/resource/node_resource_test.go
@@ -1,0 +1,946 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils/resources"
+	"github.com/kaito-project/kaito/pkg/utils/test"
+)
+
+func TestNewNodeResourceManager(t *testing.T) {
+	mockClient := test.NewClient()
+
+	manager := NewNodeResourceManager(mockClient)
+
+	assert.NotNil(t, manager)
+	assert.Equal(t, mockClient, manager.Client)
+}
+
+func TestEnsureNodeResource(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     *kaitov1beta1.Workspace
+		setup         func(*test.MockClient)
+		expectedReady bool
+		expectedError bool
+	}{
+		{
+			name: "Should succeed when instance type has no known GPU config",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_D2s_v3", // Non-GPU instance type
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get for workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock list nodes for label selector matching
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock status update for updateWorkspaceStatusIfNeeded
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should succeed when GPU instance type and device plugins are ready",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3", // GPU instance type
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock nodeclaim.GetRequiredNodeClaimsCount
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock nodeclaim.GetExistingNodeClaims
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Mock Get for workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should fail when device plugins check fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3", // GPU instance type
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock nodeclaim.GetRequiredNodeClaimsCount to fail
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(errors.New("list failed"))
+			},
+			expectedReady: false,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			ready, err := manager.EnsureNodeResource(context.Background(), tt.workspace)
+
+			assert.Equal(t, tt.expectedReady, ready)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEnsureNvidiaDevicePluginsReady(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     *kaitov1beta1.Workspace
+		setup         func(*test.MockClient)
+		expectedReady bool
+		expectedError bool
+	}{
+		{
+			name: "Should fail when GetRequiredNodeClaimsCount fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+			},
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(errors.New("list failed"))
+			},
+			expectedReady: false,
+			expectedError: true,
+		},
+		{
+			name: "Should fail when getReadyNodesFromNodeClaims fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock successful GetRequiredNodeClaimsCount (returns 0 for no BYO nodes)
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock failing GetExistingNodeClaims
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(errors.New("nodeclaim list failed"))
+
+				// Mock status update for error condition
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: true,
+		},
+		{
+			name: "Should wait when node count does not match target",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+				Status: kaitov1beta1.WorkspaceStatus{
+					Inference: &kaitov1beta1.InferenceStatus{
+						TargetNodeCount: 1,
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock GetRequiredNodeClaimsCount returns 1 (1 required, 0 BYO)
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock GetExistingNodeClaims returns empty list (0 nodes)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Mock status update for node count mismatch
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: false,
+		},
+		{
+			name: "Should add accelerator label and succeed when node lacks it",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+				Status: kaitov1beta1.WorkspaceStatus{
+					Inference: &kaitov1beta1.InferenceStatus{
+						TargetNodeCount: 1,
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock BYO nodes (empty list for GetRequiredNodeClaimsCount to return 1)
+				nodeList := &corev1.NodeList{}
+				mockClient.CreateMapWithType(nodeList)
+
+				// Mock GetExistingNodeClaims returns one NodeClaim
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+				nodeClaimList := &karpenterv1.NodeClaimList{}
+				nodeClaimMap := mockClient.CreateMapWithType(nodeClaimList)
+				objKey := client.ObjectKeyFromObject(nodeClaim)
+				nodeClaimMap[objKey] = nodeClaim
+
+				// Set up List mock for both node and nodeclaim lists
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Create a node without accelerator label but with GPU capacity
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("1"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock node update
+				mockClient.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should wait when node has zero GPU capacity",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock GetRequiredNodeClaimsCount returns 0
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock GetExistingNodeClaims returns one NodeClaim
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(nodeClaim)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Create a node with accelerator label but zero GPU capacity
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+							resources.LabelKeyNvidia:       resources.LabelValueNvidia,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("0"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update for GPU capacity not ready
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			ready, err := manager.ensureNvidiaDevicePluginsReady(context.Background(), tt.workspace)
+
+			assert.Equal(t, tt.expectedReady, ready)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetReadyNodesFromNodeClaims(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     *kaitov1beta1.Workspace
+		setup         func(*test.MockClient)
+		expectedNodes int
+		expectedError bool
+	}{
+		{
+			name: "Should return error when GetExistingNodeClaims fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+			},
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(errors.New("list failed"))
+			},
+			expectedNodes: 0,
+			expectedError: true,
+		},
+		{
+			name: "Should skip NodeClaim without assigned node",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim without NodeName
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "", // No node assigned
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(nodeClaim)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should skip when node doesn't exist",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim with NodeName
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "nonexistent-node",
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(nodeClaim)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Mock Get to return NotFound error
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "nonexistent-node"))
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should return error when node Get fails with non-NotFound error",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim with NodeName
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+
+				// Create map and add NodeClaim
+				nodeClaimList := &karpenterv1.NodeClaimList{}
+				relevantMap := mockClient.CreateMapWithType(nodeClaimList)
+				objKey := client.ObjectKeyFromObject(nodeClaim)
+				relevantMap[objKey] = nodeClaim
+
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Mock Get to return a different error
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("api server error"))
+			},
+			expectedNodes: 0,
+			expectedError: true,
+		},
+		{
+			name: "Should skip node that is not ready",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(nodeClaim)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Create a node that is not ready
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should skip node with different instance type",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(nodeClaim)
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Create a ready node with different instance type
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_D2s_v3", // Different instance type
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should return ready node with matching instance type",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType: "Standard_NC12s_v3",
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock NodeClaim
+				nodeClaim := &karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim",
+					},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				}
+
+				// Create map and add NodeClaim
+				nodeClaimList := &karpenterv1.NodeClaimList{}
+				relevantMap := mockClient.CreateMapWithType(nodeClaimList)
+				objKey := client.ObjectKeyFromObject(nodeClaim)
+				relevantMap[objKey] = nodeClaim
+
+				mockClient.On("List", mock.Anything, mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				// Create a ready node with matching instance type
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 1,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			nodes, err := manager.getReadyNodesFromNodeClaims(context.Background(), tt.workspace)
+
+			assert.Len(t, nodes, tt.expectedNodes)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetReadyNodesMatchingLabelSelector(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     *kaitov1beta1.Workspace
+		setup         func(*test.MockClient)
+		expectedNodes int
+		expectedError bool
+	}{
+		{
+			name: "Should return error when label selector is invalid",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "invalid",
+								Operator: metav1.LabelSelectorOperator("invalid-operator"),
+							},
+						},
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// No setup needed for invalid label selector
+			},
+			expectedNodes: 0,
+			expectedError: true,
+		},
+		{
+			name: "Should return error when node list fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+			},
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(errors.New("list failed"))
+			},
+			expectedNodes: 0,
+			expectedError: true,
+		},
+		{
+			name: "Should return ready nodes without label selector",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					LabelSelector: nil,
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create ready and not ready nodes
+				readyNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ready-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				notReadyNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "not-ready-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+
+				// Create map and add nodes
+				nodeList := &corev1.NodeList{}
+				relevantMap := mockClient.CreateMapWithType(nodeList)
+				readyKey := client.ObjectKeyFromObject(readyNode)
+				notReadyKey := client.ObjectKeyFromObject(notReadyNode)
+				relevantMap[readyKey] = readyNode
+				relevantMap[notReadyKey] = notReadyNode
+
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+			},
+			expectedNodes: 1, // Only ready node should be returned
+			expectedError: false,
+		},
+		{
+			name: "Should return ready nodes matching label selector",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create ready node with matching label
+				matchingNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "matching-node",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				// Create map and add node
+				nodeList := &corev1.NodeList{}
+				relevantMap := mockClient.CreateMapWithType(nodeList)
+				objKey := client.ObjectKeyFromObject(matchingNode)
+				relevantMap[objKey] = matchingNode
+
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+			},
+			expectedNodes: 1,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			nodes, err := manager.getReadyNodesMatchingLabelSelector(context.Background(), tt.workspace)
+
+			assert.Len(t, nodes, tt.expectedNodes)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateWorkspaceStatusIfNeeded(t *testing.T) {
+	tests := []struct {
+		name          string
+		workspace     *kaitov1beta1.Workspace
+		setup         func(*test.MockClient)
+		expectedError bool
+	}{
+		{
+			name: "Should return error when getting ready nodes fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+			},
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(errors.New("list failed"))
+			},
+			expectedError: true,
+		},
+		{
+			name: "Should return early when no updates needed",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Status: kaitov1beta1.WorkspaceStatus{
+					WorkerNodes: []string{}, // Empty worker nodes
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(kaitov1beta1.ConditionTypeResourceStatus),
+							Status: metav1.ConditionTrue,
+							Reason: "ResourcesReady",
+						},
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock empty node list - no ready nodes found
+				nodeList := &corev1.NodeList{}
+				mockClient.CreateMapWithType(nodeList)
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+			},
+			expectedError: false,
+		},
+		{
+			name: "Should update when worker nodes differ",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Status: kaitov1beta1.WorkspaceStatus{
+					WorkerNodes: []string{"old-node"},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(kaitov1beta1.ConditionTypeResourceStatus),
+							Status: metav1.ConditionTrue,
+							Reason: "ResourcesReady",
+						},
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a different ready node
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "new-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+				// Mock the retry update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			err := manager.updateWorkspaceStatusIfNeeded(context.Background(), tt.workspace)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateWorkspaceStatusWithBothUpdates(t *testing.T) {
+	tests := []struct {
+		name                 string
+		workerNodes          []string
+		updateWorkerNodes    bool
+		updateResourceStatus bool
+		setup                func(*test.MockClient)
+		expectedError        bool
+	}{
+		{
+			name:                 "Should succeed with both updates",
+			workerNodes:          []string{"node1", "node2"},
+			updateWorkerNodes:    true,
+			updateResourceStatus: true,
+			setup: func(mockClient *test.MockClient) {
+				workspace := &kaitov1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				}
+				mockClient.CreateOrUpdateObjectInMap(workspace)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedError: false,
+		},
+		{
+			name:                 "Should succeed with only worker nodes update",
+			workerNodes:          []string{"node1"},
+			updateWorkerNodes:    true,
+			updateResourceStatus: false,
+			setup: func(mockClient *test.MockClient) {
+				workspace := &kaitov1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				}
+				mockClient.CreateOrUpdateObjectInMap(workspace)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedError: false,
+		},
+		{
+			name:                 "Should return early when workspace not found",
+			workerNodes:          []string{"node1"},
+			updateWorkerNodes:    true,
+			updateResourceStatus: true,
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "workspaces"}, "test-workspace"))
+			},
+			expectedError: false,
+		},
+		{
+			name:                 "Should return error when Get fails with non-NotFound error",
+			workerNodes:          []string{"node1"},
+			updateWorkerNodes:    true,
+			updateResourceStatus: true,
+			setup: func(mockClient *test.MockClient) {
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("api server error"))
+			},
+			expectedError: true,
+		},
+		{
+			name:                 "Should return error when status update fails",
+			workerNodes:          []string{"node1"},
+			updateWorkerNodes:    true,
+			updateResourceStatus: true,
+			setup: func(mockClient *test.MockClient) {
+				workspace := &kaitov1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				}
+				mockClient.CreateOrUpdateObjectInMap(workspace)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("update failed"))
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeResourceManager(mockClient)
+			nameKey := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
+			err := manager.updateWorkspaceStatusWithBothUpdates(context.Background(), nameKey, tt.workerNodes, tt.updateWorkerNodes, tt.updateResourceStatus)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
… label

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:


___

### **PR Type**
Enhancement


___

### **Description**
- Added `NodeResourceManager` for managing node resources in the workspace.

- Implemented methods to ensure NVIDIA device plugins are ready and update workspace status.

- Added utility functions to get NodeClaims and calculate required NodeClaims count.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node_resource_test.go</strong><dd><code>Add unit tests for NodeResourceManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workspace/resource/node_resource_test.go

<li>Added comprehensive unit tests for <code>NodeResourceManager</code>.<br> <li> Covered scenarios including non-GPU and GPU instance types, device <br>plugin readiness, and status updates.


</details>


  </td>
  <td><a href="https://github.com/bfoley13/kaito/pull/7/files#diff-d94eb45e40a729580adf32da89f882fc2fab442071f60a9d16663d888c731fa4">+946/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node_resource.go</strong><dd><code>Implement NodeResourceManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/workspace/resource/node_resource.go

<li>Introduced <code>NodeResourceManager</code> struct and its methods.<br> <li> Implemented logic to ensure NVIDIA device plugins are ready and update <br>workspace status accordingly.


</details>


  </td>
  <td><a href="https://github.com/bfoley13/kaito/pull/7/files#diff-03e39be69d0b19698b5b6ad96983efbd8e92d62c1c144d092cd202e11584d67b">+330/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nodeclaim.go</strong><dd><code>Add NodeClaim utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/nodeclaim/nodeclaim.go

<li>Added functions to get BringYourOwnNodes, existing NodeClaims, and <br>required NodeClaims count.<br> <li> Included utility function to check if a node is ready.


</details>


  </td>
  <td><a href="https://github.com/bfoley13/kaito/pull/7/files#diff-3f8d1cc39df925fb39b051cf3e06d7be7959a0b0a93191cc40cc0422753c26f0">+111/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>status.go</strong></td>
  <td><a href="https://github.com/bfoley13/kaito/pull/7/files#diff-762bb2efea004785dbc2ab861d61d025ef5f3fa022f040ccf4c28646fc0cc705">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>